### PR TITLE
Use redirect_stderr=false for eventlisteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ example:
     user=user_00
     events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
     autorestart=true
-    redirect_stderr=true
+    redirect_stderr=false
 
 注意: 
 


### PR DESCRIPTION
[README.md](https://github.com/dantezhu/svdog/blob/764d2be9f5d9363ebff10dda66132760d7b184e0/README.md):

> supervisor 3.2.0 及之后的版本，开始不允许 eventlistener 类型使用 redirect_stderr=true

This is correct, but `redirect_stderr=true` should not be used with an eventlistener for any version of Supervisor.  If `redirect_stderr=true` and any output is written to `stderr`, the message will be mixed with `stdout` and will violate the [eventlistener protocol](http://supervisord.org/events.html#event-listener-notification-protocol).  If this happens, `supervisord` will stop sending events to the eventlistener.  That is why `redirect_stderr=true` was disallowed starting in 3.2.0.
